### PR TITLE
feat: add include/exclude pattern support for directory processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ go install github.com/arthur-debert/nanodoc-go/cmd/nanodoc@latest
 - **Simple file bundling**: Combine multiple text files into one document
 - **Bundle files**: Create reusable file lists with `.bundle.*` files
 - **Live bundles**: Include files inline using `[[file:path]]` syntax
-- **Line ranges**: Extract specific lines with `file.txt:L10-20` syntax in bundle files
+- **Line ranges**: Extract specific lines with `file.txt:L10-20` syntax
+- **Pattern filtering**: Include/exclude files with gitignore-style patterns
 - **Line numbering**: Add line numbers per-file (`-n`) or globally (`-nn`)
 - **Table of contents**: Generate TOC with `--toc`
 - **Multiple themes**: Built-in themes (classic, classic-light, classic-dark)
@@ -73,6 +74,12 @@ nanodoc --theme=classic-dark --no-header *.md
 
 # Use glob patterns
 nanodoc src/*.go docs/*.md
+
+# Include/exclude patterns for directories
+nanodoc docs/ --include="**/api/*.md" --exclude="**/internal/**"
+
+# Process only Go source files, excluding tests
+nanodoc src/ --txt-ext=go --include="**/*.go" --exclude="**/*_test.go"
 ```
 
 ### Bundle Files
@@ -141,6 +148,8 @@ Flags:
       --sequence string       Header sequence type (numerical, letter, roman) (default "numerical")
       --style string          Header style (nice, filename, path) (default "nice")
       --txt-ext strings       Additional file extensions to process
+      --include strings       Include only files matching these patterns (gitignore-style)
+      --exclude strings       Exclude files matching these patterns (gitignore-style)
       --dry-run               Preview what files would be processed without processing them
   -v, --verbose               Enable verbose output
   -h, --help                  Help for nanodoc

--- a/cmd/nanodoc/patterns_test.go
+++ b/cmd/nanodoc/patterns_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRootCmdWithPatterns(t *testing.T) {
+	tempDir, cleanup := setupTest(t)
+	defer cleanup()
+	
+	// Create test directory structure
+	testFiles := map[string]string{
+		"api/users.md":       "# Users API\nUser endpoints",
+		"api/auth.md":        "# Auth API\nAuthentication",
+		"api/test/test.md":   "# Test API\nTest file",
+		"docs/README.md":     "# README\nDocumentation",
+		"docs/guide.md":      "# Guide\nUser guide",
+		"internal/notes.md":  "# Internal\nInternal notes",
+		"test/unit.md":       "# Unit Tests\nUnit test docs",
+	}
+	
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tempDir, path)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	
+	tests := []struct {
+		name          string
+		args          []string
+		wantContains  []string
+		dontWant      []string
+		wantErr       bool
+	}{
+		{
+			name: "include pattern",
+			args: []string{tempDir, "--include", "**/api/*.md"},
+			wantContains: []string{
+				"Users API",
+				"Auth API",
+			},
+			dontWant: []string{
+				"README",
+				"Guide",
+				"Internal",
+				"Test API", // in api/test/
+			},
+		},
+		{
+			name: "exclude pattern",
+			args: []string{tempDir, "--exclude", "**/README.md", "--exclude", "**/test/**"},
+			wantContains: []string{
+				"Users API",
+				"Auth API",
+				"Guide",
+				"Internal",
+			},
+			dontWant: []string{
+				"README",
+				"Test API",
+				"Unit Tests",
+			},
+		},
+		{
+			name: "include and exclude combined",
+			args: []string{tempDir, "--include", "**/*.md", "--exclude", "**/internal/**", "--exclude", "**/test/**"},
+			wantContains: []string{
+				"Users API",
+				"Auth API",
+				"README",
+				"Guide",
+			},
+			dontWant: []string{
+				"Internal",
+				"Test API",
+				"Unit Tests",
+			},
+		},
+		{
+			name: "patterns with additional extensions",
+			args: []string{tempDir, "--txt-ext", "go", "--include", "**/api/**"},
+			wantContains: []string{
+				"Users API",
+				"Auth API",
+				"Test API", // Now included because it's under api/
+			},
+			dontWant: []string{
+				"README",
+				"Guide",
+				"Internal",
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags()
+			
+			output, err := executeCommand(tt.args...)
+			
+			if (err != nil) != tt.wantErr {
+				t.Errorf("executeCommand() error = %v, wantErr %v\nOutput:\n%s", err, tt.wantErr, output)
+				return
+			}
+			
+			for _, want := range tt.wantContains {
+				if !strings.Contains(output, want) {
+					t.Errorf("Output does not contain %q.\nGot:\n%s", want, output)
+				}
+			}
+			
+			for _, dontWant := range tt.dontWant {
+				if strings.Contains(output, dontWant) {
+					t.Errorf("Output contains %q, but should not.\nGot:\n%s", dontWant, output)
+				}
+			}
+		})
+	}
+}

--- a/cmd/nanodoc/root_test.go
+++ b/cmd/nanodoc/root_test.go
@@ -273,8 +273,20 @@ func newRootCmd() (*cobra.Command, *nanodoc.FormattingOptions) {
 			if cmd.Flags().Changed("txt-ext") {
 				explicitFlags["txt-ext"] = true
 			}
+			if cmd.Flags().Changed("include") {
+				explicitFlags["include"] = true
+			}
+			if cmd.Flags().Changed("exclude") {
+				explicitFlags["exclude"] = true
+			}
 
-			pathInfos, err := nanodoc.ResolvePaths(args)
+			// Resolve paths with pattern options
+			pathOpts := &nanodoc.FormattingOptions{
+				AdditionalExtensions: additionalExt,
+				IncludePatterns: includePatterns,
+				ExcludePatterns: excludePatterns,
+			}
+			pathInfos, err := nanodoc.ResolvePathsWithOptions(args, pathOpts)
 			if err != nil {
 				return fmt.Errorf("Error resolving paths: %w", err)
 			}
@@ -294,6 +306,8 @@ func newRootCmd() (*cobra.Command, *nanodoc.FormattingOptions) {
 				SequenceStyle: nanodoc.SequenceStyle(sequence),
 				HeaderStyle:   nanodoc.HeaderStyle(headerStyle),
 				AdditionalExtensions: additionalExt,
+				IncludePatterns: includePatterns,
+				ExcludePatterns: excludePatterns,
 			}
 
 			doc, err := nanodoc.BuildDocumentWithExplicitFlags(pathInfos, opts, explicitFlags)
@@ -326,6 +340,8 @@ func newRootCmd() (*cobra.Command, *nanodoc.FormattingOptions) {
 	cmd.Flags().StringVar(&headerStyle, "header-style", "nice", "Set the header style")
 	cmd.Flags().StringVar(&sequence, "sequence", "numerical", "Set the sequence style")
 	cmd.Flags().StringSliceVar(&additionalExt, "txt-ext", []string{}, "Additional file extensions")
+	cmd.Flags().StringSliceVar(&includePatterns, "include", []string{}, "Include only files matching these patterns")
+	cmd.Flags().StringSliceVar(&excludePatterns, "exclude", []string{}, "Exclude files matching these patterns")
 
 	return cmd, &opts
 }

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,117 @@
+# Include/Exclude Patterns
+
+Nanodoc supports gitignore-style patterns for fine-grained control over which files are processed when working with directories.
+
+## Basic Usage
+
+### Include Patterns
+Process only files matching specific patterns:
+```bash
+# Include only markdown files in api directories
+nanodoc docs/ --include="**/api/*.md"
+
+# Include multiple patterns
+nanodoc . --include="**/*.md" --include="**/*.txt"
+```
+
+### Exclude Patterns
+Exclude files matching specific patterns:
+```bash
+# Exclude README files
+nanodoc docs/ --exclude="**/README.md"
+
+# Exclude test files and draft content
+nanodoc . --exclude="**/*_test.go" --exclude="**/draft-*"
+```
+
+### Combining Include and Exclude
+When both are specified, files must match include patterns and NOT match exclude patterns:
+```bash
+# Process all markdown files except those in test directories
+nanodoc . --include="**/*.md" --exclude="**/test/**"
+
+# Process API docs but exclude internal directories
+nanodoc docs/ --include="**/api/**" --exclude="**/internal/**"
+```
+
+## Pattern Syntax
+
+Patterns follow gitignore-style syntax:
+
+- `*` matches any string within a path segment
+- `**` matches zero or more directories
+- `?` matches any single character
+- `[abc]` matches any character in the set
+
+### Examples
+
+| Pattern | Matches | Doesn't Match |
+|---------|---------|---------------|
+| `*.md` | `file.md` | `dir/file.md` |
+| `**/*.md` | `file.md`, `dir/file.md`, `a/b/c/file.md` | `file.txt` |
+| `api/*.md` | `api/users.md` | `api/v1/users.md` |
+| `**/api/*.md` | `api/users.md`, `docs/api/users.md` | `api/v1/users.md` |
+| `**/test/**` | `test/file.md`, `src/test/file.go` | `test.md` |
+| `README.*` | `README.md`, `README.txt` | `README/file.md` |
+
+## Directory Traversal
+
+- Without patterns: Only processes files in the specified directory (non-recursive)
+- With patterns containing `**`: Recursively traverses subdirectories
+- With patterns not containing `**`: Non-recursive (current behavior)
+
+## Bundle File Support
+
+Include/exclude patterns can be specified in bundle files:
+
+```
+# docs.bundle.txt
+--include **/api/*.md
+--exclude **/internal/**
+--exclude **/test/**
+
+# Additional files can be listed
+important.md
+```
+
+## Integration with Other Features
+
+Patterns work seamlessly with other nanodoc features:
+
+```bash
+# With additional extensions
+nanodoc src/ --txt-ext=go --include="**/*.go" --exclude="**/*_test.go"
+
+# With formatting options
+nanodoc docs/ --include="**/api/**" --theme=dark --toc
+
+# With line ranges
+nanodoc . --include="**/*.md" --exclude="**/README.md" src/file.go:L10-20
+```
+
+## Use Cases
+
+### Documentation Generation
+```bash
+# Include only public API documentation
+nanodoc docs/ --include="**/api/**" --exclude="**/internal/**"
+```
+
+### Code Review Preparation
+```bash
+# Include source files but exclude tests and examples
+nanodoc src/ --txt-ext=go --include="**/*.go" --exclude="**/*_test.go" --exclude="**/examples/**"
+```
+
+### Project Overview
+```bash
+# Include all markdown files except generated ones
+nanodoc . --include="**/*.md" --exclude="**/node_modules/**" --exclude="**/vendor/**" --exclude="**/.git/**"
+```
+
+## Precedence Rules
+
+1. If no patterns are specified, all text files in the directory are included
+2. If include patterns are specified, only matching files are considered
+3. Exclude patterns are always applied last and take precedence
+4. Command-line patterns override bundle file patterns

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.9.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.9.0 h1:DBvuZxjdKkRP/dr4GVV4w2fnmrk5Hxc90T51LZjv0JA=
+github.com/bmatcuk/doublestar/v4 v4.9.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/pkg/nanodoc/bundle_patterns_test.go
+++ b/pkg/nanodoc/bundle_patterns_test.go
@@ -1,0 +1,128 @@
+package nanodoc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBundleWithPatterns(t *testing.T) {
+	// Create test directory
+	tmpDir := t.TempDir()
+	
+	// Create test files
+	testFiles := map[string]string{
+		"api/users.md":      "# Users API",
+		"api/auth.md":       "# Auth API", 
+		"test/test.md":      "# Test",
+		"internal/notes.md": "# Internal",
+		"README.md":         "# README",
+	}
+	
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tmpDir, path)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	
+	// Create bundle file with patterns
+	bundleContent := `# Bundle with patterns
+--include **/api/*.md
+--exclude **/*test*
+.
+`
+	bundlePath := filepath.Join(tmpDir, "docs.bundle.txt")
+	if err := os.WriteFile(bundlePath, []byte(bundleContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	
+	// Process bundle
+	bp := NewBundleProcessor()
+	result, err := bp.ProcessBundleFileWithOptions(bundlePath)
+	if err != nil {
+		t.Fatalf("ProcessBundleFileWithOptions() error = %v", err)
+	}
+	
+	// Check options were parsed
+	if len(result.Options.IncludePatterns) != 1 || result.Options.IncludePatterns[0] != "**/api/*.md" {
+		t.Errorf("Expected include pattern '**/api/*.md', got %v", result.Options.IncludePatterns)
+	}
+	
+	if len(result.Options.ExcludePatterns) != 1 || result.Options.ExcludePatterns[0] != "**/*test*" {
+		t.Errorf("Expected exclude pattern '**/*test*', got %v", result.Options.ExcludePatterns)
+	}
+	
+	// Test merging with command-line options
+	cmdOpts := FormattingOptions{
+		Theme: "dark",
+		ExcludePatterns: []string{"**/README.md"},
+	}
+	
+	mergedOpts := MergeFormattingOptions(result.Options, cmdOpts)
+	
+	// Check that patterns were merged
+	if len(mergedOpts.IncludePatterns) != 1 {
+		t.Errorf("Expected 1 include pattern, got %d", len(mergedOpts.IncludePatterns))
+	}
+	
+	// Command-line excludes should be added to bundle excludes
+	if len(mergedOpts.ExcludePatterns) != 2 {
+		t.Errorf("Expected 2 exclude patterns, got %d: %v", len(mergedOpts.ExcludePatterns), mergedOpts.ExcludePatterns)
+	}
+}
+
+func TestParseOptionWithPatterns(t *testing.T) {
+	tests := []struct {
+		name       string
+		optionLine string
+		wantInclude []string
+		wantExclude []string
+		wantErr    bool
+	}{
+		{
+			name:       "include pattern",
+			optionLine: "--include **/api/*.md",
+			wantInclude: []string{"**/api/*.md"},
+		},
+		{
+			name:       "exclude pattern",
+			optionLine: "--exclude **/test/**",
+			wantExclude: []string{"**/test/**"},
+		},
+		{
+			name:       "include without value",
+			optionLine: "--include",
+			wantErr:    true,
+		},
+		{
+			name:       "exclude without value",
+			optionLine: "--exclude",
+			wantErr:    true,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var options BundleOptions
+			err := parseOption(tt.optionLine, &options)
+			
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseOption() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			
+			if len(options.IncludePatterns) != len(tt.wantInclude) {
+				t.Errorf("Expected %d include patterns, got %d", len(tt.wantInclude), len(options.IncludePatterns))
+			}
+			
+			if len(options.ExcludePatterns) != len(tt.wantExclude) {
+				t.Errorf("Expected %d exclude patterns, got %d", len(tt.wantExclude), len(options.ExcludePatterns))
+			}
+		})
+	}
+}

--- a/pkg/nanodoc/dryrun.go
+++ b/pkg/nanodoc/dryrun.go
@@ -214,14 +214,21 @@ func uniqueStrings(slice []string) []string {
 
 // isTextFileWithExtensions checks if a file is a text file considering additional extensions
 func isTextFileWithExtensions(path string, additionalExtensions []string) bool {
-	// First check default extensions
-	if isTextFile(path) {
-		return true
+	ext := strings.ToLower(filepath.Ext(path))
+	
+	// Check default extensions
+	for _, validExt := range DefaultTextExtensions {
+		if ext == validExt {
+			return true
+		}
 	}
 	
 	// Then check additional extensions
-	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
 	for _, addExt := range additionalExtensions {
+		// Normalize extension (add leading dot if missing)
+		if !strings.HasPrefix(addExt, ".") {
+			addExt = "." + addExt
+		}
 		if ext == strings.ToLower(addExt) {
 			return true
 		}

--- a/pkg/nanodoc/dryrun_test.go
+++ b/pkg/nanodoc/dryrun_test.go
@@ -343,7 +343,7 @@ func TestIsTextFileWithExtensions(t *testing.T) {
 			name: "extension with dot in additional extensions",
 			path: "/tmp/file.py",
 			additionalExtensions: []string{".py"},
-			want: false, // Should not match because we trim the dot
+			want: true, // Should match - we normalize extensions
 		},
 	}
 

--- a/pkg/nanodoc/patterns.go
+++ b/pkg/nanodoc/patterns.go
@@ -1,0 +1,102 @@
+package nanodoc
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// PatternMatcher handles include/exclude pattern matching for files
+type PatternMatcher struct {
+	includePatterns []string
+	excludePatterns []string
+	baseDir         string
+	needsRecursion  bool
+}
+
+// NewPatternMatcher creates a new pattern matcher
+func NewPatternMatcher(baseDir string, includePatterns, excludePatterns []string) *PatternMatcher {
+	pm := &PatternMatcher{
+		includePatterns: includePatterns,
+		excludePatterns: excludePatterns,
+		baseDir:         baseDir,
+	}
+	
+	// Check if any pattern requires recursion
+	pm.needsRecursion = pm.hasRecursivePattern()
+	
+	return pm
+}
+
+// hasRecursivePattern checks if any pattern contains ** which requires recursive traversal
+func (pm *PatternMatcher) hasRecursivePattern() bool {
+	for _, pattern := range pm.includePatterns {
+		if strings.Contains(pattern, "**") {
+			return true
+		}
+	}
+	for _, pattern := range pm.excludePatterns {
+		if strings.Contains(pattern, "**") {
+			return true
+		}
+	}
+	return false
+}
+
+// NeedsRecursion returns true if recursive directory traversal is needed
+func (pm *PatternMatcher) NeedsRecursion() bool {
+	return pm.needsRecursion
+}
+
+// ShouldInclude determines if a file should be included based on patterns
+func (pm *PatternMatcher) ShouldInclude(filePath string) (bool, error) {
+	// Get relative path from base directory
+	relPath, err := filepath.Rel(pm.baseDir, filePath)
+	if err != nil {
+		// If we can't get relative path, use the full path
+		relPath = filePath
+	}
+	
+	// Normalize path separators for pattern matching
+	relPath = filepath.ToSlash(relPath)
+	
+	// Check include patterns
+	included := true
+	if len(pm.includePatterns) > 0 {
+		included = false
+		for _, pattern := range pm.includePatterns {
+			match, err := doublestar.Match(pattern, relPath)
+			if err != nil {
+				return false, err
+			}
+			if match {
+				included = true
+				break
+			}
+		}
+	}
+	
+	// If not included, no need to check excludes
+	if !included {
+		return false, nil
+	}
+	
+	// Check exclude patterns - they take precedence
+	for _, pattern := range pm.excludePatterns {
+		match, err := doublestar.Match(pattern, relPath)
+		if err != nil {
+			return false, err
+		}
+		if match {
+			return false, nil
+		}
+	}
+	
+	return true, nil
+}
+
+// HasPatterns returns true if any include or exclude patterns are specified
+func (pm *PatternMatcher) HasPatterns() bool {
+	return len(pm.includePatterns) > 0 || len(pm.excludePatterns) > 0
+}

--- a/pkg/nanodoc/patterns_test.go
+++ b/pkg/nanodoc/patterns_test.go
@@ -1,0 +1,167 @@
+package nanodoc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPatternMatcher(t *testing.T) {
+	// Create a test directory structure
+	tmpDir := t.TempDir()
+	
+	// Create test files
+	testFiles := map[string]string{
+		"api/users.md":           "# Users API",
+		"api/auth.md":            "# Auth API",
+		"api/test/auth_test.md":  "# Auth API Tests",
+		"docs/README.md":         "# README",
+		"docs/api-guide.md":      "# API Guide",
+		"internal/notes.md":      "# Internal Notes",
+		"test/integration.md":    "# Integration Tests",
+		"examples/sample.md":     "# Sample",
+		"node_modules/pkg/doc.md": "# Package Doc",
+	}
+	
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tmpDir, path)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	
+	tests := []struct {
+		name            string
+		baseDir         string
+		includePatterns []string
+		excludePatterns []string
+		file            string
+		wantInclude     bool
+		wantRecursion   bool
+	}{
+		{
+			name:        "no patterns - include all",
+			baseDir:     tmpDir,
+			file:        filepath.Join(tmpDir, "api/users.md"),
+			wantInclude: true,
+		},
+		{
+			name:            "include pattern with **",
+			baseDir:         tmpDir,
+			includePatterns: []string{"**/api/*.md"},
+			file:            filepath.Join(tmpDir, "api/users.md"),
+			wantInclude:     true,
+			wantRecursion:   true,
+		},
+		{
+			name:            "include pattern without match",
+			baseDir:         tmpDir,
+			includePatterns: []string{"**/api/*.md"},
+			file:            filepath.Join(tmpDir, "docs/README.md"),
+			wantInclude:     false,
+			wantRecursion:   true,
+		},
+		{
+			name:            "exclude pattern",
+			baseDir:         tmpDir,
+			excludePatterns: []string{"**/README.md"},
+			file:            filepath.Join(tmpDir, "docs/README.md"),
+			wantInclude:     false,
+			wantRecursion:   true,
+		},
+		{
+			name:            "exclude takes precedence",
+			baseDir:         tmpDir,
+			includePatterns: []string{"**/*.md"},
+			excludePatterns: []string{"**/test/*.md"},
+			file:            filepath.Join(tmpDir, "api/test/auth_test.md"),
+			wantInclude:     false,
+			wantRecursion:   true,
+		},
+		{
+			name:            "exclude entire directory",
+			baseDir:         tmpDir,
+			excludePatterns: []string{"**/node_modules/**"},
+			file:            filepath.Join(tmpDir, "node_modules/pkg/doc.md"),
+			wantInclude:     false,
+			wantRecursion:   true,
+		},
+		{
+			name:            "simple pattern without **",
+			baseDir:         tmpDir,
+			includePatterns: []string{"api/*.md"},
+			file:            filepath.Join(tmpDir, "api/users.md"),
+			wantInclude:     true,
+			wantRecursion:   false,
+		},
+		{
+			name:            "prefix pattern",
+			baseDir:         tmpDir,
+			includePatterns: []string{"**/api-*.md"},
+			file:            filepath.Join(tmpDir, "docs/api-guide.md"),
+			wantInclude:     true,
+			wantRecursion:   true,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewPatternMatcher(tt.baseDir, tt.includePatterns, tt.excludePatterns)
+			
+			if got := matcher.NeedsRecursion(); got != tt.wantRecursion {
+				t.Errorf("NeedsRecursion() = %v, want %v", got, tt.wantRecursion)
+			}
+			
+			got, err := matcher.ShouldInclude(tt.file)
+			if err != nil {
+				t.Fatalf("ShouldInclude() error = %v", err)
+			}
+			if got != tt.wantInclude {
+				t.Errorf("ShouldInclude(%s) = %v, want %v", tt.file, got, tt.wantInclude)
+			}
+		})
+	}
+}
+
+func TestPatternMatcherHasPatterns(t *testing.T) {
+	tests := []struct {
+		name            string
+		includePatterns []string
+		excludePatterns []string
+		want            bool
+	}{
+		{
+			name: "no patterns",
+			want: false,
+		},
+		{
+			name:            "has include patterns",
+			includePatterns: []string{"*.md"},
+			want:            true,
+		},
+		{
+			name:            "has exclude patterns",
+			excludePatterns: []string{"*.txt"},
+			want:            true,
+		},
+		{
+			name:            "has both patterns",
+			includePatterns: []string{"*.md"},
+			excludePatterns: []string{"*.txt"},
+			want:            true,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewPatternMatcher("/tmp", tt.includePatterns, tt.excludePatterns)
+			if got := matcher.HasPatterns(); got != tt.want {
+				t.Errorf("HasPatterns() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/nanodoc/resolver_patterns_test.go
+++ b/pkg/nanodoc/resolver_patterns_test.go
@@ -1,0 +1,266 @@
+package nanodoc
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestResolvePathsWithPatterns(t *testing.T) {
+	// Create test directory structure
+	tmpDir := t.TempDir()
+	
+	// Create test files
+	testFiles := map[string]string{
+		"api/users.md":           "# Users API",
+		"api/auth.go":            "package auth",
+		"api/test/users_test.go": "package auth_test",
+		"docs/README.md":         "# README",
+		"docs/api-guide.txt":     "API Guide",
+		"internal/notes.md":      "# Internal",
+		"examples/sample.go":     "package main",
+		"test/integration.md":    "# Tests",
+	}
+	
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tmpDir, path)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	
+	tests := []struct {
+		name            string
+		source          string
+		options         *FormattingOptions
+		wantFiles       []string // relative paths from tmpDir
+		wantErr         bool
+	}{
+		{
+			name:   "directory without patterns",
+			source: filepath.Join(tmpDir, "api"),
+			wantFiles: []string{
+				"api/users.md",
+			},
+		},
+		{
+			name:   "directory with include pattern",
+			source: filepath.Join(tmpDir),
+			options: &FormattingOptions{
+				IncludePatterns: []string{"**/api/*.md"},
+			},
+			wantFiles: []string{
+				"api/users.md",
+			},
+		},
+		{
+			name:   "directory with exclude pattern",
+			source: filepath.Join(tmpDir),
+			options: &FormattingOptions{
+				ExcludePatterns: []string{"**/README.md"},
+			},
+			wantFiles: []string{
+				"api/users.md",
+				"docs/api-guide.txt", // .txt is a default extension
+				"internal/notes.md",
+				"test/integration.md",
+			},
+		},
+		{
+			name:   "include and exclude patterns",
+			source: filepath.Join(tmpDir),
+			options: &FormattingOptions{
+				IncludePatterns: []string{"**/*.md"},
+				ExcludePatterns: []string{"**/test/**", "**/README.md"},
+			},
+			wantFiles: []string{
+				"api/users.md",
+				"internal/notes.md",
+			},
+		},
+		{
+			name:   "additional extensions with patterns",
+			source: filepath.Join(tmpDir),
+			options: &FormattingOptions{
+				AdditionalExtensions: []string{".go"},
+				IncludePatterns:      []string{"**/api/**"},
+			},
+			wantFiles: []string{
+				"api/auth.go",
+				"api/test/users_test.go",
+				"api/users.md",
+			},
+		},
+		{
+			name:   "glob with patterns not supported",
+			source: filepath.Join(tmpDir, "**/*.md"),
+			options: &FormattingOptions{
+				ExcludePatterns: []string{"**/README.md"},
+			},
+			wantFiles: []string{
+				"api/users.md",
+				"docs/README.md", // Patterns not applied to glob results
+				"internal/notes.md",
+				"test/integration.md",
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathInfos, err := ResolvePathsWithOptions([]string{tt.source}, tt.options)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolvePathsWithOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			
+			if tt.wantErr {
+				return
+			}
+			
+			// Collect all resolved files
+			var gotFiles []string
+			for _, info := range pathInfos {
+				switch info.Type {
+				case "file":
+					rel, _ := filepath.Rel(tmpDir, info.Absolute)
+					gotFiles = append(gotFiles, rel)
+				case "directory", "glob":
+					for _, f := range info.Files {
+						rel, _ := filepath.Rel(tmpDir, f)
+						gotFiles = append(gotFiles, rel)
+					}
+				}
+			}
+			
+			// Sort for consistent comparison
+			sort.Strings(gotFiles)
+			sort.Strings(tt.wantFiles)
+			
+			if len(gotFiles) != len(tt.wantFiles) {
+				t.Errorf("Got %d files, want %d files", len(gotFiles), len(tt.wantFiles))
+				t.Errorf("Got files: %v", gotFiles)
+				t.Errorf("Want files: %v", tt.wantFiles)
+				return
+			}
+			
+			for i, got := range gotFiles {
+				if got != tt.wantFiles[i] {
+					t.Errorf("File[%d] = %v, want %v", i, got, tt.wantFiles[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDirectoryTraversalWithPatterns(t *testing.T) {
+	// Create nested directory structure
+	tmpDir := t.TempDir()
+	
+	// Create files at various depths
+	testFiles := map[string]string{
+		"README.md":                        "# Root",
+		"api/v1/users.md":                  "# Users V1",
+		"api/v2/users.md":                  "# Users V2",
+		"api/v2/internal/schema.md":        "# Schema",
+		"docs/api/reference.md":            "# Reference",
+		"docs/guides/quickstart.md":        "# Quickstart",
+		"vendor/github.com/foo/README.md":  "# Vendor",
+	}
+	
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tmpDir, path)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	
+	tests := []struct {
+		name      string
+		patterns  *FormattingOptions
+		wantCount int
+		wantFiles []string // Sample files to check
+	}{
+		{
+			name:      "no patterns - non-recursive",
+			patterns:  &FormattingOptions{},
+			wantCount: 1, // Only README.md at root
+			wantFiles: []string{"README.md"},
+		},
+		{
+			name: "** pattern enables recursion",
+			patterns: &FormattingOptions{
+				IncludePatterns: []string{"**/*.md"},
+			},
+			wantCount: 7, // All .md files
+		},
+		{
+			name: "exclude vendor directory",
+			patterns: &FormattingOptions{
+				IncludePatterns: []string{"**/*.md"},
+				ExcludePatterns: []string{"**/vendor/**"},
+			},
+			wantCount: 6, // All except vendor
+		},
+		{
+			name: "include only api directories",
+			patterns: &FormattingOptions{
+				IncludePatterns: []string{"**/api/**/*.md"},
+			},
+			wantCount: 4, // Only files under api directories
+			wantFiles: []string{
+				"api/v1/users.md",
+				"api/v2/users.md",
+				"api/v2/internal/schema.md",
+				"docs/api/reference.md",
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathInfos, err := ResolvePathsWithOptions([]string{tmpDir}, tt.patterns)
+			if err != nil {
+				t.Fatalf("ResolvePathsWithOptions() error = %v", err)
+			}
+			
+			var files []string
+			for _, info := range pathInfos {
+				if info.Type == "directory" {
+					files = append(files, info.Files...)
+				}
+			}
+			
+			if len(files) != tt.wantCount {
+				t.Errorf("Got %d files, want %d", len(files), tt.wantCount)
+				for _, f := range files {
+					rel, _ := filepath.Rel(tmpDir, f)
+					t.Logf("  %s", rel)
+				}
+			}
+			
+			// Check specific files if provided
+			if len(tt.wantFiles) > 0 {
+				fileMap := make(map[string]bool)
+				for _, f := range files {
+					rel, _ := filepath.Rel(tmpDir, f)
+					fileMap[rel] = true
+				}
+				
+				for _, want := range tt.wantFiles {
+					if !fileMap[want] {
+						t.Errorf("Expected file %s not found", want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/nanodoc/structures.go
+++ b/pkg/nanodoc/structures.go
@@ -80,6 +80,12 @@ type FormattingOptions struct {
 
 	// Additional file extensions to process
 	AdditionalExtensions []string
+	
+	// Include patterns for file filtering (gitignore-style)
+	IncludePatterns []string
+	
+	// Exclude patterns for file filtering (gitignore-style)
+	ExcludePatterns []string
 }
 
 // NewRange creates a new Range with validation


### PR DESCRIPTION
## Summary

Implements gitignore-style pattern matching for fine-grained control over which files are processed when working with directories.

## Features

- ✅ Add `--include` and `--exclude` CLI flags supporting multiple patterns
- ✅ Support gitignore-style patterns with `**` for recursive matching
- ✅ Enable recursive directory traversal when `**` patterns are used
- ✅ Add pattern support in bundle files
- ✅ Maintain backward compatibility (non-recursive by default)

## Pattern Matching

- `*` matches any string within a path segment
- `**` matches zero or more directories  
- `?` matches any single character
- Patterns match against relative paths from base directory
- Exclude patterns take precedence over include patterns

## Usage Examples

```bash
# Include only API documentation
nanodoc docs/ --include="**/api/*.md"

# Exclude test files and README
nanodoc . --exclude="**/test/**" --exclude="**/README.md"

# Process Go source files, excluding tests
nanodoc src/ --txt-ext=go --include="**/*.go" --exclude="**/*_test.go"
```

## Bundle File Support

Patterns can also be specified in bundle files:

```
# docs.bundle.txt
--include **/api/*.md
--exclude **/internal/**
file1.md
file2.md
```

## Implementation Details

- Uses `github.com/bmatcuk/doublestar/v4` for robust gitignore-style pattern matching
- Patterns are evaluated during path resolution, before file content is read
- Directory traversal is only recursive when patterns contain `**`
- Comprehensive test coverage: unit tests, integration tests, and bundle file tests

## Documentation

- Added `docs/patterns.md` with detailed usage guide
- Updated README.md with examples and feature description
- Added pattern flags to CLI help

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)